### PR TITLE
Checks database before computing stats

### DIFF
--- a/backend/src/main/java/dev/revature/fantasy/repository/RosterUserRepo.java
+++ b/backend/src/main/java/dev/revature/fantasy/repository/RosterUserRepo.java
@@ -2,11 +2,16 @@ package dev.revature.fantasy.repository;
 
 import dev.revature.fantasy.model.RosterUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface RosterUserRepo extends JpaRepository<RosterUser, Long>, RosterUserRepoCustom {
     public Optional<RosterUser> findByUserIdAndLeagueId(String userId, String leagueId);
 
     public Optional<RosterUser> findByRosterIdAndLeagueId(Integer rosterId, String leagueId);
+
+    public List<RosterUser> findRosterUsersByLeagueId(String leagueId);
 }

--- a/backend/src/main/java/dev/revature/fantasy/service/FantasyStatsService.java
+++ b/backend/src/main/java/dev/revature/fantasy/service/FantasyStatsService.java
@@ -71,11 +71,42 @@ public class FantasyStatsService {
     }
 
     /**
-     * Run the compute luck stats endpoint logic
+     * Run the compute luck stats endpoint logic. Requires that the leagueId be valid
+     * and already in the database.
      * @param leagueId the sleeper league id to get the stats for
      * @return the league stats dto, not sure when this would/should be empty
      */
     public Optional<LeagueStatsDto> computeStats(String leagueId) {
+        // TODO: check if there are weekscores already in database for this league
+        // and that there are the correct amount of weeks, and users
+
+        // get the nfl state info from sleeper
+        SleeperNFLStateResponse nflState = ResponseFormatter.getNFLState();
+        int currentWeek = Integer.parseInt(nflState.getDisplayWeek());
+        int currSeason = Integer.parseInt(nflState.getDisplayWeek());
+        int numWeeksToCompute = currentWeek - 1;
+
+        int sizeOfLeague = this.leagueService.getSizeOfLeague(leagueId);
+
+        // see if weekscores already in database for this league
+        List<List<WeekScore>> weekScores = this.weekScoreService.findWeekScoresByLeagueId(leagueId, numWeeksToCompute);
+        int numWeeksFound = weekScores.size();
+
+        if (numWeeksFound == numWeeksToCompute) {
+            boolean allWeeksFound = true;
+            for (List<WeekScore> weekScoreList : weekScores) {
+                if (weekScoreList.size() != sizeOfLeague) {
+                    allWeeksFound = false;
+                    break;
+                }
+            }
+            if (allWeeksFound) { // all weeks found, just need roster to return
+                List<RosterUser> rosterUsers = this.rosterUserService.getAllRosterUsersByLeagueId(leagueId);
+                var optionalStatsDto = this.weekScoresToStatsDto(weekScores, rosterUsers);
+                return optionalStatsDto;
+            }
+        }
+
         // make sleeper request with leagueId to get users
         List<SleeperUserResponse> sleeperUsers = ResponseFormatter.getUsersFromLeague(leagueId);
         if (sleeperUsers.size() == 0) {
@@ -94,32 +125,39 @@ public class FantasyStatsService {
         // persist to database, need to upsert incase a users' stats (wins, etc) changed
         List<RosterUser> rosterUsers = this.rosterUserService.upsertUsers(rosterUserDtos);
 
-        // TODO: implement a way to have league specific timestamps when data was persisted
-        // to 'cache' result
-
-        // get the nfl state info from sleeper
-        SleeperNFLStateResponse nflState = ResponseFormatter.getNFLState();
-        int currentWeek = Integer.parseInt(nflState.getDisplayWeek());
-        int currSeason = Integer.parseInt(nflState.getDisplayWeek());
-
         // make matchup requests for each week from sleeper
-        List<WeekScore> weekScores = new ArrayList<>();
-        for (int week = 1; week < currentWeek; week++) {
+        // starting from the first week we don't have
+        weekScores.clear();
+        List<WeekScore> weekScoresToPersist = new ArrayList<>();
+        for (int week = numWeeksFound + 1; week <= numWeeksToCompute; week++) {
             var matchups = ResponseFormatter.getMatchupsFromLeagueIdAndWeek(leagueId, week);
             // convertTo WeekScores for computation
             var scores = this.databaseFormatterService.formatMatchups(matchups, leagueId, week);
 
-            weekScores.addAll(scores);
+            weekScoresToPersist.addAll(scores);
         }
         // persist weekscores all at once with idempotency
-        this.weekScoreService.upsertWeekScores(weekScores);
+        this.weekScoreService.upsertWeekScores(weekScoresToPersist);
 
         // get weekscores from database
-        List<List<WeekScore>> allWeekScores = this.weekScoreService.findWeekScoresByLeagueId(leagueId, currentWeek);
+        List<List<WeekScore>> allWeekScores =
+                this.weekScoreService.findWeekScoresByLeagueId(leagueId, numWeeksToCompute);
 
         // do stats computation
         // need the rosterUserIds
-        LuckData luckData = this.statsComputationService.computeStats(rosterUsers, allWeekScores);
+        return this.weekScoresToStatsDto(allWeekScores, rosterUsers);
+    }
+
+    /**
+     * Does the stats computation and returns the stats dto for stats endpoint
+     * response. Requires that the parameters are compatible, ie that the weekScores
+     * reference the same rosterUsers.
+     * @param weekScores the weekscores for the league
+     * @param rosterUsers the rosters for the league
+     */
+    private Optional<LeagueStatsDto> weekScoresToStatsDto(
+            List<List<WeekScore>> weekScores, List<RosterUser> rosterUsers) {
+        LuckData luckData = this.statsComputationService.computeStats(rosterUsers, weekScores);
 
         // get the names of the roster users
         Map<Long, String> rosterUserIdToName = this.rosterUserService.getRosterUserIdToName(rosterUsers);

--- a/backend/src/main/java/dev/revature/fantasy/service/LeagueService.java
+++ b/backend/src/main/java/dev/revature/fantasy/service/LeagueService.java
@@ -6,6 +6,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class LeagueService {
@@ -19,5 +20,15 @@ public class LeagueService {
     public List<League> idempotentSave(List<League> leagues) {
         this.leagueRepo.batchIdempotentSave(leagues);
         return leagues;
+    }
+
+    /**
+     * Returns the size of the league, or -1 if not found in database
+     * @param leagueId the league id
+     * @return the number of players in the league
+     */
+    public int getSizeOfLeague(String leagueId) {
+        Optional<League> league = this.leagueRepo.findById(leagueId);
+        return league.isPresent() ? league.get().getNumRosters() : -1;
     }
 }

--- a/backend/src/main/java/dev/revature/fantasy/service/RosterUserService.java
+++ b/backend/src/main/java/dev/revature/fantasy/service/RosterUserService.java
@@ -28,6 +28,10 @@ public class RosterUserService {
         return repo.findByUserIdAndLeagueId(userId, leagueId);
     }
 
+    public List<RosterUser> getAllRosterUsersByLeagueId(String leagueId) {
+        return repo.findRosterUsersByLeagueId(leagueId);
+    }
+
     public Optional<RosterUser> getRosterUserByRosterIdAndLeagueId(Integer rosterId, String leagueId) {
         return repo.findByRosterIdAndLeagueId(rosterId, leagueId);
     }

--- a/backend/src/main/java/dev/revature/fantasy/service/WeekScoreService.java
+++ b/backend/src/main/java/dev/revature/fantasy/service/WeekScoreService.java
@@ -15,14 +15,28 @@ public class WeekScoreService {
         this.repo = repo;
     }
 
+    /**
+     * Gets all week scores for a given league up to a max week, inclusive.
+     * @param leagueId the league id
+     * @param maxWeek the max week to get week scores for
+     * @return a list of lists of week scores, where each inner list is the week scores for a given week
+     */
     public List<List<WeekScore>> findWeekScoresByLeagueId(String leagueId, int maxWeek) {
         List<List<WeekScore>> allWeekScores = new ArrayList<>();
-        for (int week = 1; week < maxWeek; week++) {
-            allWeekScores.add(this.repo.findWeekScoresByIdWeekNumAndLeagueId(week, leagueId));
+        for (int week = 1; week <= maxWeek; week++) {
+            var currWeekScores = this.repo.findWeekScoresByIdWeekNumAndLeagueId(week, leagueId);
+            if (currWeekScores.size() == 0) { // no scores for this week so no need to look further
+                return allWeekScores; // return what we have so far
+            }
+            allWeekScores.add(currWeekScores);
         }
         return allWeekScores;
     }
 
+    /**
+     * Upserts a list of week scores to database.
+     * @param weekScores the week scores to upsert
+     */
     public void upsertWeekScores(List<WeekScore> weekScores) {
         this.repo.batchUpsert(weekScores);
     }


### PR DESCRIPTION
If all scores for a league are already present, then the stats endpoint makes significantly less sleeper calls. Cuts time on endpoint from 2+ seconds to < 500 ms.